### PR TITLE
공통 cache decorator & interceptor 구현

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,1 +1,0 @@
-export * from "./logging.interceptor";

--- a/src/common/interceptor/http.cache.interceptor.spec.ts
+++ b/src/common/interceptor/http.cache.interceptor.spec.ts
@@ -1,0 +1,235 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpCacheInterceptor } from './http.cache.interceptor';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of } from 'rxjs';
+import { plainToInstance } from 'class-transformer';
+
+jest.mock('class-transformer', () => ({
+  plainToInstance: jest.fn(),
+}));
+
+describe('HttpCacheInterceptor', () => {
+  let interceptor: HttpCacheInterceptor;
+  let cacheManager: any;
+  let reflector: Reflector;
+  let mockExecutionContext: ExecutionContext;
+  let mockCallHandler: CallHandler;
+  let mockRequest: any;
+
+  beforeEach(async () => {
+    const mockCacheManager = {
+      get: jest.fn(),
+      set: jest.fn(),
+    };
+
+    const mockReflector = {
+      get: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HttpCacheInterceptor,
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
+        },
+        {
+          provide: Reflector,
+          useValue: mockReflector,
+        },
+      ],
+    }).compile();
+
+    interceptor = module.get<HttpCacheInterceptor>(HttpCacheInterceptor);
+    cacheManager = module.get(CACHE_MANAGER);
+    reflector = module.get<Reflector>(Reflector);
+
+    mockRequest = {
+      method: 'GET',
+      originalUrl: '/test/path',
+      locals: {},
+    };
+
+    mockExecutionContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue(mockRequest),
+      }),
+      getHandler: jest.fn(),
+    } as any;
+
+    mockCallHandler = {
+      handle: jest.fn().mockReturnValue(of('response data')),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(interceptor).toBeDefined();
+  });
+
+  describe('intercept', () => {
+    it('should return next.handle() when no cache key is generated', async () => {
+      jest.spyOn(interceptor as any, 'trackBy').mockReturnValue(undefined);
+      reflector.get = jest.fn().mockReturnValue({ ttl: 60 });
+
+      const result = await interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+      expect(result).toBe(mockCallHandler.handle());
+      expect(cacheManager.get).not.toHaveBeenCalled();
+    });
+
+    it('should return next.handle() when no caching options are found', async () => {
+      jest.spyOn(interceptor as any, 'trackBy').mockReturnValue('/test/path');
+      reflector.get = jest.fn().mockReturnValue(null);
+
+      const result = await interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+      expect(result).toBe(mockCallHandler.handle());
+      expect(cacheManager.get).not.toHaveBeenCalled();
+    });
+
+    it('should set cached data to req.locals when cache hit occurs', async () => {
+      const cachedData = { id: 1, name: 'test' };
+      const options = { ttl: 60 };
+
+      jest.spyOn(interceptor as any, 'trackBy').mockReturnValue('/test/path');
+      reflector.get = jest.fn().mockReturnValue(options);
+      cacheManager.get = jest.fn().mockResolvedValue(cachedData);
+
+      await interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+      expect(cacheManager.get).toHaveBeenCalledWith('/test/path');
+      expect(mockRequest.locals.data).toBe(cachedData);
+    });
+
+    it('should transform cached data using schema when provided', async () => {
+      const cachedData = { id: 1, name: 'test' };
+      const transformedData = { id: 1, name: 'test', transformed: true };
+      const schema = class TestSchema {};
+      const options = { ttl: 60, schema };
+
+      jest.spyOn(interceptor as any, 'trackBy').mockReturnValue('/test/path');
+      reflector.get = jest.fn().mockReturnValue(options);
+      cacheManager.get = jest.fn().mockResolvedValue(cachedData);
+      (plainToInstance as jest.Mock).mockReturnValue(transformedData);
+
+      await interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+      expect(plainToInstance).toHaveBeenCalledWith(schema, cachedData);
+      expect(mockRequest.locals.data).toBe(transformedData);
+    });
+
+    it('should set undefined to req.locals.data when no cache hit and no schema', async () => {
+      const options = { ttl: 60 };
+
+      jest.spyOn(interceptor as any, 'trackBy').mockReturnValue('/test/path');
+      reflector.get = jest.fn().mockReturnValue(options);
+      cacheManager.get = jest.fn().mockResolvedValue(undefined);
+
+      await interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+      expect(mockRequest.locals.data).toBeUndefined();
+    });
+
+    it('should cache response data when cache miss occurs', async () => {
+      const responseData = { id: 1, name: 'response' };
+      const options = { ttl: 60 };
+
+      jest.spyOn(interceptor as any, 'trackBy').mockReturnValue('/test/path');
+      reflector.get = jest.fn().mockReturnValue(options);
+      cacheManager.get = jest.fn().mockResolvedValue(undefined);
+      cacheManager.set = jest.fn().mockResolvedValue(undefined);
+      mockCallHandler.handle = jest.fn().mockReturnValue(of(responseData));
+
+      const result$ = await interceptor.intercept(mockExecutionContext, mockCallHandler);
+      
+      result$.subscribe(() => {
+        setTimeout(() => {
+          expect(cacheManager.set).toHaveBeenCalledWith('/test/path', responseData, 60);
+        }, 0);
+      });
+    });
+
+    it('should handle cache set errors gracefully', async () => {
+      const responseData = { id: 1, name: 'response' };
+      const options = { ttl: 60 };
+      const loggerSpy = jest.spyOn(interceptor['logger'], 'error').mockImplementation();
+
+      jest.spyOn(interceptor as any, 'trackBy').mockReturnValue('/test/path');
+      reflector.get = jest.fn().mockReturnValue(options);
+      cacheManager.get = jest.fn().mockResolvedValue(undefined);
+      cacheManager.set = jest.fn().mockRejectedValue(new Error('Cache error'));
+      mockCallHandler.handle = jest.fn().mockReturnValue(of(responseData));
+
+      const result$ = await interceptor.intercept(mockExecutionContext, mockCallHandler);
+      
+      result$.subscribe(() => {
+        setTimeout(() => {
+          expect(loggerSpy).toHaveBeenCalledWith(new Error('Cache error'));
+        }, 0);
+      });
+    });
+
+    it('should not cache when cached data already exists', async () => {
+      const cachedData = { id: 1, name: 'cached' };
+      const responseData = { id: 2, name: 'response' };
+      const options = { ttl: 60 };
+
+      jest.spyOn(interceptor as any, 'trackBy').mockReturnValue('/test/path');
+      reflector.get = jest.fn().mockReturnValue(options);
+      cacheManager.get = jest.fn().mockResolvedValue(cachedData);
+      mockCallHandler.handle = jest.fn().mockReturnValue(of(responseData));
+
+      const result$ = await interceptor.intercept(mockExecutionContext, mockCallHandler);
+      
+      result$.subscribe(() => {
+        setTimeout(() => {
+          expect(cacheManager.set).not.toHaveBeenCalled();
+        }, 0);
+      });
+    });
+  });
+
+  describe('trackBy', () => {
+    it('should return originalUrl for GET requests', () => {
+      mockRequest.method = 'GET';
+      mockRequest.originalUrl = '/api/test';
+
+      const result = interceptor['trackBy'](mockExecutionContext);
+
+      expect(result).toBe('/api/test');
+    });
+
+    it('should return undefined for non-GET requests', () => {
+      mockRequest.method = 'POST';
+      mockRequest.originalUrl = '/api/test';
+
+      const result = interceptor['trackBy'](mockExecutionContext);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for PUT requests', () => {
+      mockRequest.method = 'PUT';
+      mockRequest.originalUrl = '/api/test';
+
+      const result = interceptor['trackBy'](mockExecutionContext);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for DELETE requests', () => {
+      mockRequest.method = 'DELETE';
+      mockRequest.originalUrl = '/api/test';
+
+      const result = interceptor['trackBy'](mockExecutionContext);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/common/interceptor/http.cache.interceptor.ts
+++ b/src/common/interceptor/http.cache.interceptor.ts
@@ -1,0 +1,54 @@
+import { CallHandler, ExecutionContext, Inject, Injectable, Logger } from "@nestjs/common";
+import { Cache, CACHE_MANAGER, CacheInterceptor } from "@nestjs/cache-manager";
+import type { Request } from "express";
+import { Observable, tap } from "rxjs";
+import { Caching } from "../../utils/decorator";
+import { plainToInstance } from "class-transformer";
+import { Reflector } from "@nestjs/core";
+
+@Injectable()
+export class HttpCacheInterceptor extends CacheInterceptor {
+    private readonly logger: Logger = new Logger(HttpCacheInterceptor.name);
+
+    constructor(
+        @Inject(CACHE_MANAGER)
+        cacheManager: Cache,
+        @Inject(Reflector)
+        reflector: Reflector,
+    ) {
+        super(cacheManager, reflector);
+    }
+
+    async intercept(ctx: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
+        const key = this.trackBy(ctx);
+        const options = this.reflector.get(Caching, ctx.getHandler());
+        if (!(key && options)) return next.handle();
+
+        const raw = await (this.cacheManager as Cache).get<any>(key);
+        const req = ctx.switchToHttp().getRequest();
+
+        req.locals = {
+            data: raw !== undefined && options.schema
+                ? plainToInstance(options.schema, raw)
+                : raw
+        };
+
+        return next.handle().pipe(
+            tap(data => {
+                if (raw === undefined) {
+                    (this.cacheManager as Cache).set(
+                        key, data, options.ttl
+                    ).catch(err => this.logger.error(err));
+                }
+            })
+        );
+    }
+
+    protected trackBy(ctx: ExecutionContext): string | undefined {
+        const req: Request = ctx.switchToHttp().getRequest();
+        return req.method === "GET" ?  req.originalUrl : undefined;
+    }
+
+
+
+}

--- a/src/common/interceptor/index.ts
+++ b/src/common/interceptor/index.ts
@@ -1,0 +1,2 @@
+export * from "./logging.interceptor";
+export * from "./http.cache.interceptor";

--- a/src/common/interceptor/logging.interceptor.ts
+++ b/src/common/interceptor/logging.interceptor.ts
@@ -11,9 +11,10 @@ import type { Request, Response } from 'express';
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
 
+
   intercept(ctx: ExecutionContext, next: CallHandler): Observable<any> {
     const now = Date.now();
-        const {method, url, headers, query, body, cookies} = ctx
+        const {method, url, headers, query, body, cookies,} = ctx
       .switchToHttp()
             .getRequest<Request>();
 

--- a/src/courses/courses.controller.ts
+++ b/src/courses/courses.controller.ts
@@ -18,6 +18,7 @@ import {
     SearchCoursesResponse
 } from "./api";
 import { AuthGuard } from "@nestjs/passport";
+import { Cache, CACHE_MANAGER } from "@nestjs/cache-manager";
 
 @ApiTags("Courses")
 @Controller("/api/courses")
@@ -29,6 +30,8 @@ export class CoursesController {
         private readonly coursesService: CoursesService,
         @Inject(SearchCoursesService)
         private readonly searchCoursesService: SearchCoursesService,
+        @Inject(CACHE_MANAGER)
+        private readonly cache: Cache,
     ) {}
 
     @Post("/")
@@ -54,6 +57,7 @@ export class CoursesController {
     async getCourse(
         @Param("id") id: number,
     ): Promise<CourseDTO> {
+
        return this.coursesService.getCourse(id);
     }
 

--- a/src/courses/dto/course.dto.ts
+++ b/src/courses/dto/course.dto.ts
@@ -1,6 +1,7 @@
 import { ApiExtraModels, ApiProperty } from "@nestjs/swagger";
 import { CourseNodeDTO } from "./course.node.dto";
-import { IsInt, IsNumber, IsString  } from "class-validator";
+import { IsInt, IsNumber, IsString, ValidateNested } from "class-validator";
+import { Type } from "class-transformer";
 
 @ApiExtraModels(CourseNodeDTO)
 export class CourseDTO {
@@ -20,6 +21,8 @@ export class CourseDTO {
     @ApiProperty({ type: "integer", description: "경로를 달린 사람 수" })
     nCompleted: number;
 
+    @ValidateNested({ each: true })
+    @Type(() => CourseNodeDTO)
     @ApiProperty({ type: [CourseNodeDTO] })
     nodes: CourseNodeDTO[];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import process from "node:process";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { initializeTransactionalContext } from "typeorm-transactional";
 import { ValidationPipe } from "@nestjs/common";
-import { LoggingInterceptor } from "./common";
+import { LoggingInterceptor } from "./common/interceptor";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { HttpExceptionFilter } from "./common/filters/http-exception.filter";
 import "./config/proj4";

--- a/src/utils/decorator/caching.ts
+++ b/src/utils/decorator/caching.ts
@@ -1,0 +1,10 @@
+import { ReflectableDecorator, Reflector } from "@nestjs/core";
+import { Clazz } from "../clazz";
+
+export interface CachingOptions {
+    ttl?: number;
+    schema?: Clazz<any>;
+}
+
+export const Caching: ReflectableDecorator<CachingOptions, CachingOptions>
+    = Reflector.createDecorator<CachingOptions>();

--- a/src/utils/decorator/http.decorators.ts
+++ b/src/utils/decorator/http.decorators.ts
@@ -11,3 +11,4 @@ function ParamDecorator(prop: string) {
 
 export const User = ParamDecorator("user");
 export const Cookies = ParamDecorator("cookies");
+export const Locals = ParamDecorator("locals");

--- a/src/utils/decorator/index.ts
+++ b/src/utils/decorator/index.ts
@@ -1,1 +1,2 @@
 export * from "./http.decorators";
+export * from "./caching";


### PR DESCRIPTION
## /utils/decorators/caching.ts
- Caching decorator를 통해, ttl & 데이터 스키마를 메타데이터로 저장
## /common/interceptor/http.cache.interceptor.ts
- 캐싱된 데이터가 존재하면,  req.locals.data에 넘김